### PR TITLE
chore: fix compilation to pipe through bundle / ignore robocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,7 @@ require:
 AllCops:
   TargetRubyVersion: 2.7
   NewCops: enable
+  SuggestExtensions: false
   Include:
     - "**/*.rb"
     - "**/*file"

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gemspec
 # Add development dependencies here
 gem 'abbrev'
 gem 'fastlane', '>= 2.225.0'
+gem 'mutex_m'
 gem 'pry'
 gem 'rake'
 gem 'rspec'

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ rename_android(
 )
 ```
 
-| Parameter | Description | Required | Default |
-|---|---|---|---|
-| `path` | Path to the Android project root | Yes | |
-| `package_name` | The current package name | Yes | |
-| `new_package_name` | The new package name | Yes | |
+| Parameter          | Description                      | Required | Default |
+|--------------------|----------------------------------|----------|---------|
+| `path`             | Path to the Android project root | Yes      |         |
+| `package_name`     | The current package name         | Yes      |         |
+| `new_package_name` | The new package name             | Yes      |         |
 
 ### rename_android_app_name
 
@@ -42,22 +42,22 @@ rename_android_app_name(
 )
 ```
 
-| Parameter | Description | Required | Default |
-|---|---|---|---|
-| `new_name` | The new display name for the app | No | |
-| `manifest` | Path to the AndroidManifest.xml file | No | `app/src/main/AndroidManifest.xml` |
+| Parameter  | Description                          | Required | Default                            |
+|------------|--------------------------------------|----------|------------------------------------|
+| `new_name` | The new display name for the app     | No       |                                    |
+| `manifest` | Path to the AndroidManifest.xml file | No       | `app/src/main/AndroidManifest.xml` |
 
 ## Run tests for this plugin
 
 To run both the tests, and code style validation, run
 
 ```
-rake
+bundle exec rake
 ```
 
 To automatically fix many of the styling issues, use
 ```
-rubocop -a
+bundle exec rubocop -a
 ```
 
 ## Issues and Feedback


### PR DESCRIPTION
* Funneling commands through `bundle exec` uses the proper dependency resolution.
* Fixed README
* Ignore suggestions from Robocop