### PR TITLE
fix: support early return if renaming to itself

### DIFF
--- a/lib/fastlane/plugin/rename_android/actions/rename_android_action.rb
+++ b/lib/fastlane/plugin/rename_android/actions/rename_android_action.rb
@@ -16,6 +16,11 @@ module Fastlane
         package_name = params[:package_name]
         new_package_name = params[:new_package_name]
 
+        if package_name == new_package_name
+          UI.message("Old and new package names are the same, nothing to do")
+          return 0
+        end
+
         folder = package_name.gsub('.', '/')
         new_folder = new_package_name.gsub('.', '/')
         new_folder_path = "#{path}/app/src/main/java/#{new_folder}"

--- a/spec/rename_android_package_spec.rb
+++ b/spec/rename_android_package_spec.rb
@@ -159,6 +159,19 @@ describe Fastlane::Actions::RenameAndroidAction do
         Fastlane::Actions::RenameAndroidAction.run(params)
       end.to raise_error(FastlaneCore::Interface::FastlaneError, "No new_package_name provided")
     end
+
+    it 'returns 0 and does nothing if package names are the same' do
+      params = {
+        path: test_path,
+        package_name: old_package,
+        new_package_name: old_package
+      }
+
+      expect(Fastlane::UI).to receive(:message).with("Old and new package names are the same, nothing to do")
+      result = Fastlane::Actions::RenameAndroidAction.run(params)
+
+      expect(result).to eq(0)
+    end
   end
 
   describe '.is_supported?' do


### PR DESCRIPTION
Fixes: #17. I am debating whether an early return is right or just skipping the file moving, since it ends up moving to itself.

You can sed something to itself for no issue and maybe thats a good safety net in case there is a partial rename going on.